### PR TITLE
package.json: Fix "name"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "asprintf.c",
+  "name": "asprintf",
   "version": "0.0.1",
   "repo": "littlstar/asprintf.c",
   "description": "asprintf() implementation",


### PR DESCRIPTION
Makes `#include <asprintf/asprintf.h>` work when installed with clib(1).
