### PR TITLE
Address gcc warning

### DIFF
--- a/asprintf.c
+++ b/asprintf.c
@@ -40,7 +40,7 @@ vasprintf (char **str, const char *fmt, va_list args) {
 
   // apply variadic arguments to
   // sprintf with format to get size
-  size = vsnprintf(NULL, size, fmt, tmpa);
+  size = vsnprintf(NULL, 0, fmt, tmpa);
 
   // toss args
   va_end(tmpa);


### PR DESCRIPTION
Passing `size` as a variable rather than literal `0` to `vsnprintf` causes
the following gcc warning:

```
asprintf.c: In function ‘vasprintf’:
asprintf.c:43:8: warning: null destination pointer [-Wformat-truncation=]
   size = vsnprintf(NULL, size, fmt, tmpa);
   ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I know that gcc has its own library implementation of this function, but it's
still worth having a portable implementation that works with gcc.